### PR TITLE
fixed showMetaData not reading from hugo.toml / config.toml. 

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,7 +5,7 @@
 {{ define "main" }}
 <div class="postWrapper">
     <h1>{{ .Title }}</h1>
-    {{ if .Params.showMetadata | default true }}
+    {{ if .Site.Params.showMetadata | default true }}
     <section class="postMetadata">
         <dl>
             {{ with .GetTerms "tags" }}


### PR DESCRIPTION
Previously would always be default of `true`