### PR TITLE
fix img overflow in posts on mobile

### DIFF
--- a/assets/sass/pages/_baseof.scss
+++ b/assets/sass/pages/_baseof.scss
@@ -7,6 +7,10 @@
   justify-content: center;
 }
 
+.content img {
+  max-width: 100%;
+}
+
 .vertical {
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
When viewing on mobile devices, large images in posts appear to overflow outside of the content element, causing horizontal scrolling and an unfavorable user experience.