### PR TITLE
Added description to single.html and head.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ hostname = "gohugo.io"
     name = "Mr Hugo"
     email = "hugo@example.com
 ```
-
 ### Social links
 
 You can also add social links. To use icons for social links, you also need to add the link to icon font to custom-head.html
@@ -76,8 +75,23 @@ readingTime = false
 ```
 
 You can also disable metadata on a specific page by adding `showMetadata = false` to front matter.
+### Description
 
+To add a site wide description, add `sitedescription` to `config.toml`. For example:
+```toml
+[params]
+sitedescription = 'Your website description'
+```
 
+You can also add a description to individual posts in you website by adding `description` to the front matter. For example:
+```
++++
+title =  'This is the post title'
+draft = false
+date = 2024-01-23
+description = 'This is the description'
++++
+```
 ### Menu
 
 To add a menu item add `[[menu.header]]` item to `config.toml`. For example:

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,6 +5,9 @@
 {{ define "main" }}
 <div class="postWrapper">
     <h1>{{ .Title }}</h1>
+    {{ if .Description}}
+    	<p>{{.Description}}</p>
+    {{ end }}
     {{ if .Params.showMetadata | default true }}
     <section class="postMetadata">
         <dl>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,5 +1,6 @@
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name = "description" content = "{{.Description | default .Site.Params.SiteDescription}}">
 
 {{ hugo.Generator }}
 


### PR DESCRIPTION
Added description site wide. When a user specifies .SiteDescription param in the config file, a description will be added to the entire site to the <meta> tag.

It also allows a person to display a short description of their post under the title. 

