### PR TITLE
Use a colour for post title which has more contrast

### DIFF
--- a/assets/sass/_global.scss
+++ b/assets/sass/_global.scss
@@ -11,7 +11,7 @@ body {
 }
 
 a {
-  color: $blue;
+  color: $orange;
 }
 
 pre code {

--- a/assets/sass/components/_post.scss
+++ b/assets/sass/components/_post.scss
@@ -6,7 +6,7 @@
 }
 
 .postTitle {
-  color: $blue;
+  color: $orange;
   text-decoration: none;
   text-transform: capitalize;
   font-family: $fontHeader;

--- a/assets/sass/utils/_variables.scss
+++ b/assets/sass/utils/_variables.scss
@@ -3,6 +3,7 @@ $darkGrey: #323232;
 $white: #f8f8ff;
 $black: #2f2f2f;
 $blue: #3366cc;
+$orange: #ffb300;
 
 $backgroundDarker: #252627;
 $backgroundDark: #292a2d;


### PR DESCRIPTION
The old blue color does not have enough contrast and I checked developer tools and it reported the blue color is not in standard with the accessibility requirements. So this should solve that. 
![image](https://github.com/LordMathis/hugo-theme-nightfall/assets/65799568/aa6b3ca1-338a-4c5d-8db0-c07603076cf8)
