### PR TITLE
fix: set default false to showMetadata

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,7 +8,7 @@
     {{ if .Description}}
     	<p>{{.Description}}</p>
     {{ end }}
-    {{ if .Params.showMetadata | default true }}
+    {{ if .Params.showMetadata | default false }}
     <section class="postMetadata">
         <dl>
             {{ with .GetTerms "tags" }}


### PR DESCRIPTION

**Issue**:  https://github.com/LordMathis/hugo-theme-nightfall/issues/40

**Problem**:
When the value `false` is passed to `Params.showMetadata`, metadata is always displayed.

**Solution**:
Changed the default value to `false`.

**Description**:
The current implementation of the `Params.showMetadata` parameter does not correctly handle the false value. When Params.showMetadata is set to false in the configuration, the theme still defaults to true, causing metadata to be displayed regardless of the user's intent. This behavior occurs because the theme's logic incorrectly assumes a default of true if any value is provided.

To resolve this issue, the logic should be updated to explicitly handle the false value, ensuring that when Params.showMetadata is set to false, metadata is not displayed. This involves modifying the theme's conditional checks to correctly recognize and apply the false setting.
