### PR TITLE
Add woff2 url for FiraMono

### DIFF
--- a/assets/sass/utils/_fonts.scss
+++ b/assets/sass/utils/_fonts.scss
@@ -3,6 +3,7 @@
     src: url("../fonts/FiraMono/FiraMono-Medium.eot");
     src: local("Fira Mono"),
          url("../fonts/FiraMono/FiraMono-Medium.eot") format("embedded-opentype"),
+         url("../fonts/FiraMono/FiraMono-Medium.woff2") format("woff2"),
          url("../fonts/FiraMono/FiraMono-Medium.woff") format("woff"),
          url("../fonts/FiraMono/FiraMono-Medium.ttf") format("truetype");
     font-weight: 500;


### PR DESCRIPTION
Thanks for the theme, it looks gorgeous!
This change shaves about 20kb from the cold load network usage, so this should be a net benefit change (pun intended).
The font file is already in the repo so I only had to change `_fonts.scss`.

P.S. I've tried to add OpenSans's woff2 to the repo using [Google Fonts Website Helper](https://gwfh.mranftl.com/fonts/open-sans?subsets=cyrillic,cyrillic-ext,greek,greek-ext,hebrew,latin,latin-ext,math,symbols,vietnamese) with all additional charsets enabled but it was as big as the `.woff` file (that is already in the repo), so I decided to not do this since I don't see the benefit. Maybe there are less charsets in the current file, but I am too lazy to check this :)