### PR TITLE
Make all external links open in new tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can configure external links to open in new tabs by adding this parameter:
 openLinksInNewTab = true
 ```
 
-When enabled, all external links (links to different domains) will automatically open in a new tab. Internal links will continue to open in the same tab.
+When enabled, all external links (links which using http(s) in the markdown-destination) will automatically open in a new tab. Internal links will continue to open in the same tab.
 
 
 ### Social links

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -18,8 +18,11 @@ theme = "hugo-theme-nightfall"
     url = "about"
 
 [params]
-user = "hello"
+user = "test"
 hostname = "gohugo.io"
+
+# You can configure external links to open in new tabs by adding this parameter
+openLinksInNewTab = true
 
 # Global metadata display settings
 # Each can be overridden in individual post frontmatter
@@ -29,7 +32,6 @@ showReadingTime = true    # Show reading time on post page
 showTags = true           # Show tags on post page
 showAuthors = true        # Show authors on post page
 showCategories = true     # Show categories on post page
-
 
   [params.author]
     name = "Hugo Nightfall"  # Website and RSS feed author

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -18,7 +18,7 @@ theme = "hugo-theme-nightfall"
     url = "about"
 
 [params]
-user = "test"
+user = "hello"
 hostname = "gohugo.io"
 
 # You can configure external links to open in new tabs by adding this parameter

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,6 @@
+{{ if site.Params.openLinksInNewTab }}
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener"{{ end }}>{{ .Text | safeHTML }}</a>
+{{ else }}
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}>{{ with .Text }}{{ . }}{{ end }}</a>
+{{ end }}
+{{- /* chomp */ -}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -26,21 +26,6 @@
         {{ partial "footer.html" . }}
     </div>
 
-    {{ if .Site.Params.openLinksInNewTab }}
-    <script>
-        // Make all external links open in new tab
-        document.addEventListener('DOMContentLoaded', function() {
-            const links = document.querySelectorAll('a[href^="http"]');
-            links.forEach(function(link) {
-                if (!link.hostname || link.hostname !== window.location.hostname) {
-                    link.target = '_blank';
-                    link.rel = 'noopener noreferrer';
-                }
-            });
-        });
-    </script>
-    {{ end }}
-
 </body>
 
 </html>


### PR DESCRIPTION
Use Hugo render-hook (https://gohugo.io/render-hooks/links/) instead of JavaScript.
Enable by setting the openLinksInNewTab param in the config file.
See: https://github.com/lordmathis/hugo-theme-nightfall#external-links
