### PR TITLE
LanguageCode (Deprecated in v0.158.0) -> Language.Locale

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -1,5 +1,5 @@
 baseURL = 'https://gohugo.io/'
-languageCode = 'en-us'
+locale = 'en-us'
 theme = "hugo-theme-nightfall"
 
 [markup]

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,3 +1,3 @@
 [module]
   [module.hugoVersion]
-    min = "0.146.0"
+    min = "0.158.0"

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
 <head>
     <title>{{ block "title" . }}

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
 
 <head>
     <title>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build.environment]
   DART_SASS_VERSION = "1.85.0"
-  HUGO_VERSION = "0.148.2"
+  HUGO_VERSION = "0.158.0"
   HUGO_ENV = "production"
   HUGO_THEME = "repo"
   HUGO_BASEURL = "https://hugo-theme-nightfall.netlify.app"

--- a/theme.toml
+++ b/theme.toml
@@ -6,7 +6,7 @@ homepage = "https://github.com/LordMathis/hugo-theme-nightfall/"
 demosite = "https://hugo-theme-nightfall.netlify.app/"
 tags = ["minimal", "dark", "blog", "sass", "multilingual"]
 features = ["blog", "sass", "dark", "multilingual"]
-min_version = "0.114.0"
+min_version = "0.158.0"
 
 [author]
 name = "Matúš Námešný"


### PR DESCRIPTION
LanguageCode

[Deprecated in v0.158.0](https://github.com/gohugoio/hugo/releases/tag/v0.158.0)
Use [Locale](https://gohugo.io/methods/site/language/#locale) instead.